### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To compile (Windows):
     cd [project folder]
     dir /b /s *.java>sources.txt
     md classes
-    javac -d classes @sources.txt
+    javac -d bin @sources.txt
     del sources.txt
 
 To compile (Linux):
@@ -22,7 +22,7 @@ To compile (Linux):
 To run:
 
     cd [project folder]
-    java -cp bin com.theaigames.blockbattle.Blockbattle [your bot1] [your bot2] 2>err.txt 1>out.txt
+    java -cp bin com.theaigames.tictactoe.Tictactoe [your bot1] [your bot2] 2>err.txt 1>out.txt
 
 [your bot1] and [your bot2] could be any command for running a bot process. For instance "java -cp /home/dev/starterbot/bin/ main.BotStarter" or "node /home/user/bot/Bot.js"
 


### PR DESCRIPTION
 * Use `bin` as directory in the Windows install example, to equal Linux's behaviour
 * Remove copy-paste errors from blockbattle bot README